### PR TITLE
Support for ssh+git and git+ssh protocols

### DIFF
--- a/deps/http-parser/http_parser.c
+++ b/deps/http-parser/http_parser.c
@@ -451,7 +451,7 @@ parse_url_char(enum state s, const char ch)
       break;
 
     case s_req_schema:
-      if (IS_ALPHA(ch)) {
+      if (IS_ALPHA(ch) || ch == '+') {
         return s;
       }
 

--- a/src/transport.c
+++ b/src/transport.c
@@ -35,6 +35,8 @@ static transport_definition transports[] = {
 	{ "file://",  git_transport_local, NULL },
 #ifdef GIT_SSH
 	{ "ssh://",   git_transport_smart, &ssh_subtransport_definition },
+  { "ssh+git://",   git_transport_smart, &ssh_subtransport_definition },
+  { "git+ssh://",   git_transport_smart, &ssh_subtransport_definition },
 #endif
 	{ NULL, 0, 0 }
 };

--- a/tests/transport/register.c
+++ b/tests/transport/register.c
@@ -44,6 +44,8 @@ void test_transport_register__custom_transport_ssh(void)
 
 #ifndef GIT_SSH
 	cl_git_fail_with(git_transport_new(&transport, NULL, "ssh://somehost:somepath"), -1);
+	cl_git_fail_with(git_transport_new(&transport, NULL, "ssh+git://somehost:somepath"), -1);
+	cl_git_fail_with(git_transport_new(&transport, NULL, "git+ssh://somehost:somepath"), -1);
 	cl_git_fail_with(git_transport_new(&transport, NULL, "git@somehost:somepath"), -1);
 #else
 	cl_git_pass(git_transport_new(&transport, NULL, "git@somehost:somepath"));
@@ -60,6 +62,8 @@ void test_transport_register__custom_transport_ssh(void)
 
 #ifndef GIT_SSH
 	cl_git_fail_with(git_transport_new(&transport, NULL, "ssh://somehost:somepath"), -1);
+	cl_git_fail_with(git_transport_new(&transport, NULL, "ssh+git://somehost:somepath"), -1);
+	cl_git_fail_with(git_transport_new(&transport, NULL, "git+ssh://somehost:somepath"), -1);
 	cl_git_fail_with(git_transport_new(&transport, NULL, "git@somehost:somepath"), -1);
 #else
 	cl_git_pass(git_transport_new(&transport, NULL, "git@somehost:somepath"));


### PR DESCRIPTION
This should add support for the `ssh+git://` and `git+ssh://` protocol schemes. The behavior is to pass directly through to the `ssh://` protocol scheme.

So, as atrocious as this is, this is a protocol that people use. From everything I can tell, they're both functionally identical to `ssh://` and are treated as such in this PR. [Here](http://git.kernel.org/cgit/git/git.git/commit/?id=c05186cc38ca4605bff1f275619d7d0faeaf2fa5) is an example of it being used in the linux kernel
