### PR TITLE
Fix degraded performance using GIT_USE_NSEC on repos cloned with GIT_USE_NSEC disabled

### DIFF
--- a/src/index.h
+++ b/src/index.h
@@ -84,6 +84,8 @@ GIT_INLINE(bool) git_index_time_eq(const git_index_time *one, const git_index_ti
 		return false;
 
 #ifdef GIT_USE_NSEC
+	if (one->nanoseconds == 0 || two->nanoseconds == 0)
+		return true;
 	if (one->nanoseconds != two->nanoseconds)
 		return false;
 #endif
@@ -109,6 +111,8 @@ GIT_INLINE(bool) git_index_entry_newer_than_index(
 		return true;
 	else if ((int32_t)index->stamp.mtime.tv_sec > entry->mtime.seconds)
 		return false;
+	else if (entry->mtime.nanoseconds == 0 || index->stamp.mtime.tv_sec == 0)
+		return true;
 	else
 		return (uint32_t)index->stamp.mtime.tv_nsec <= entry->mtime.nanoseconds;
 #else


### PR DESCRIPTION
Fix degrade performance using GIT_USE_NSEC on repos cloned with GIT_USE_NSEC disabled.
We just mimic the GIT_USE_NSEC disabled behavior when nanoseconds are 0.
There is a edge case when nanoseconds is 0 in a repo cloned with GIT_USE_NSEC enabled, never found it but anyway that file will be handle fine just the sha1 will be generated to check if has changed.

Enabling GIT_USE_NSEC we will get a boost performance in LFS repos using long running process filter.
Using long running process filter the LFS files and the index will have similar timestamp, the only difference is nanoseconds, if you execute git_status_list_new withouth GIT_USE_NSEC then the clean filter will triggered because the seconds are the same in LFS files and index because of the batch mode ("git lfs checkout")