### PR TITLE
Fix the GIT_USE_NSEC performance fix

### DIFF
--- a/src/index.h
+++ b/src/index.h
@@ -111,7 +111,7 @@ GIT_INLINE(bool) git_index_entry_newer_than_index(
 		return true;
 	else if ((int32_t)index->stamp.mtime.tv_sec > entry->mtime.seconds)
 		return false;
-	else if (entry->mtime.nanoseconds == 0 || index->stamp.mtime.tv_sec == 0)
+	else if (entry->mtime.nanoseconds == 0 || index->stamp.mtime.tv_nsec == 0)
 		return true;
 	else
 		return (uint32_t)index->stamp.mtime.tv_nsec <= entry->mtime.nanoseconds;


### PR DESCRIPTION
There is a typo, Instead comparing nanoseconds to zero the code is comparing seconds to zero