### PR TITLE
stash: partial stash specific files

### DIFF
--- a/include/git2/stash.h
+++ b/include/git2/stash.h
@@ -133,7 +133,9 @@ GIT_EXTERN(int) git_stash_save_options_init(
  * or error code.
  */
 GIT_EXTERN(int) git_stash_save_with_opts(
-	git_oid *out, git_repository *repo, git_stash_save_options *opts);
+	git_oid *out,
+	git_repository *repo,
+	const git_stash_save_options *opts);
 
 /** Stash application flags. */
 typedef enum {

--- a/include/git2/stash.h
+++ b/include/git2/stash.h
@@ -45,6 +45,11 @@ typedef enum {
 	 * the working directory
 	 */
 	GIT_STASH_INCLUDE_IGNORED = (1 << 2),
+
+	/**
+	 * All changes in the index and working directory are left intact
+	 */
+	GIT_STASH_KEEP_ALL = (1 << 3),
 } git_stash_flags;
 
 /**
@@ -70,6 +75,65 @@ GIT_EXTERN(int) git_stash_save(
 	const git_signature *stasher,
 	const char *message,
 	uint32_t flags);
+
+/**
+ * Stash save options structure
+ *
+ * Initialize with `GIT_STASH_SAVE_OPTIONS_INIT`. Alternatively, you can
+ * use `git_stash_save_options_init`.
+ *
+ */
+typedef struct git_stash_save_options {
+	unsigned int version;
+
+	/** The identity of the person performing the stashing. */
+	const git_signature *stasher;
+
+	/** Optional description along with the stashed state. */
+	const char *message;
+
+	/** Flags to control the stashing process. (see GIT_STASH_* above) */
+	uint32_t flags;
+
+	/** Optional paths that control which files are stashed. */
+	git_strarray paths;
+} git_stash_save_options;
+
+#define GIT_STASH_SAVE_OPTIONS_VERSION 1
+#define GIT_STASH_SAVE_OPTIONS_INIT { \
+	GIT_STASH_SAVE_OPTIONS_VERSION, \
+	NULL, \
+	NULL, \
+	GIT_STASH_DEFAULT }
+
+/**
+ * Initialize git_stash_save_options structure
+ *
+ * Initializes a `git_stash_save_options` with default values. Equivalent to
+ * creating an instance with `GIT_STASH_SAVE_OPTIONS_INIT`.
+ *
+ * @param opts The `git_stash_save_options` struct to initialize.
+ * @param version The struct version; pass `GIT_STASH_SAVE_OPTIONS_VERSION`.
+ * @return Zero on success; -1 on failure.
+ */
+GIT_EXTERN(int) git_stash_save_options_init(
+	git_stash_save_options *opts, unsigned int version);
+
+/**
+ * Save the local modifications to a new stash, with options.
+ * 
+ * @param out Object id of the commit containing the stashed state.
+ * This commit is also the target of the direct reference refs/stash.
+ *
+ * @param repo The owning repository.
+ *
+ * @param opts The stash options.
+ *
+ * @return 0 on success, GIT_ENOTFOUND where there's nothing to stash,
+ * or error code.
+ */
+GIT_EXTERN(int) git_stash_save_with_opts(
+	git_oid *out, git_repository *repo, git_stash_save_options *opts);
 
 /** Stash application flags. */
 typedef enum {

--- a/src/stash.c
+++ b/src/stash.c
@@ -197,7 +197,7 @@ static int stash_to_index(
 static int stash_update_index_from_paths(
 	git_repository *repo,
 	git_index *index,
-	git_strarray *paths)
+	const git_strarray *paths)
 {
 	unsigned int status_flags;
 	size_t i;
@@ -422,7 +422,7 @@ static int build_stash_commit_from_tree(
 	git_commit *i_commit,
 	git_commit *b_commit,
 	git_commit *u_commit,
-	git_tree *tree)
+	const git_tree *tree)
 {
 	const git_commit *parents[] = {	NULL, NULL, NULL };
 
@@ -615,7 +615,7 @@ static int has_changes_cb(const char *path, unsigned int status, void *payload) 
 static int ensure_there_are_changes_to_stash_paths(
 	git_repository *repo,
 	uint32_t flags,
-	git_strarray *paths)
+	const git_strarray *paths)
 {
 	int error;
 	git_status_options opts = GIT_STATUS_OPTIONS_INIT;
@@ -676,7 +676,7 @@ int git_stash_save(
 }
 
 int git_stash_save_with_opts(
-	git_oid *out, git_repository *repo, git_stash_save_options *opts)
+	git_oid *out, git_repository *repo, const git_stash_save_options *opts)
 {
 	git_index *index = NULL, *paths_index = NULL;
 	git_commit *b_commit = NULL, *i_commit = NULL, *u_commit = NULL;

--- a/src/stash.c
+++ b/src/stash.c
@@ -666,6 +666,9 @@ int git_stash_save(
 	uint32_t flags)
 {
 	git_stash_save_options opts = GIT_STASH_SAVE_OPTIONS_INIT;
+	
+	GIT_ASSERT_ARG(stasher);
+	
 	opts.stasher = stasher;
 	opts.message = message;
 	opts.flags = flags;
@@ -680,10 +683,15 @@ int git_stash_save_with_opts(
 	git_buf msg = GIT_BUF_INIT;
 	git_tree *tree = NULL;
 	git_reference *head = NULL;
+	bool has_paths = false;
+
 	int error;
 
 	GIT_ASSERT_ARG(out);
 	GIT_ASSERT_ARG(repo);
+	GIT_ASSERT_ARG(opts && opts->stasher);
+
+	has_paths = opts->paths.count > 0;
 
 	if ((error = git_repository__ensure_not_bare(repo, "stash save")) < 0)
 		return error;
@@ -691,10 +699,10 @@ int git_stash_save_with_opts(
 	if ((error = retrieve_base_commit_and_message(&b_commit, &msg, repo)) < 0)
 		goto cleanup;
 
-	if (opts->paths.count == 0 &&
+	if (!has_paths &&
 		  (error = ensure_there_are_changes_to_stash(repo, opts->flags)) < 0)
 		goto cleanup;
-	else if (opts->paths.count > 0 &&
+	else if (has_paths &&
 		  (error = ensure_there_are_changes_to_stash_paths(
 			  repo, opts->flags, &opts->paths)) < 0)
 		goto cleanup;
@@ -714,7 +722,7 @@ int git_stash_save_with_opts(
 	if ((error = prepare_worktree_commit_message(&msg, opts->message)) < 0)
 		goto cleanup;
 
-	if (opts->paths.count == 0) {
+	if (!has_paths) {
 		if ((error = commit_worktree(out, repo, opts->stasher, git_buf_cstr(&msg),
 					     i_commit, b_commit, u_commit)) < 0)
 			goto cleanup;
@@ -755,9 +763,12 @@ cleanup:
 	git_commit_free(b_commit);
 	git_commit_free(u_commit);
 	git_tree_free(tree);
-	git_reference_free(head);
-	git_index_free(index);
-	git_index_free(paths_index);
+	
+	if (has_paths) {
+		git_reference_free(head);
+		git_index_free(index);
+		git_index_free(paths_index);
+	}
 
 	return error;
 }

--- a/tests/core/structinit.c
+++ b/tests/core/structinit.c
@@ -160,6 +160,11 @@ void test_core_structinit__compare(void)
 		git_stash_apply_options, GIT_STASH_APPLY_OPTIONS_VERSION, \
 		GIT_STASH_APPLY_OPTIONS_INIT, git_stash_apply_options_init);
 
+	/* stash save */
+	CHECK_MACRO_FUNC_INIT_EQUAL( \
+		git_stash_save_options, GIT_STASH_SAVE_OPTIONS_VERSION, \
+		GIT_STASH_SAVE_OPTIONS_INIT, git_stash_save_options_init);
+
 	/* status */
 	CHECK_MACRO_FUNC_INIT_EQUAL( \
 		git_status_options, GIT_STATUS_OPTIONS_VERSION, \


### PR DESCRIPTION
Copy-pasted from main libgit2 repo:

There's this concept called partial stashing in Git where users are able to stash desired files without having to stash and also reset the entire workdir. I based my implementation on tiennou's suggestion from #4725. This introduces options to git_stash_save where developers are able to supply the paths that they want to have stashed from the workdir. I could have gone further and have exposed a git_index* option as tiennou suggested, but I chose not to at this moment. Let me know if I should expose a git_index* option so that users can supply an arbitrary index to be stashed.

I also introduced GIT_STASH_KEEP_ALL, which prevents resetting the index and workdir once a stash has been completed.